### PR TITLE
Added fix for race condition which leads to channels blocking on write

### DIFF
--- a/upnp/event.go
+++ b/upnp/event.go
@@ -283,6 +283,6 @@ func MakeReactor() Reactor {
 	reactor.eventMap = make(upnpEventMap)
 	reactor.subscrChan = make(chan *upnpEventRecord, 1)
 	reactor.unpackChan = make(chan *upnpEvent, 1)
-	reactor.eventChan = make(chan Event, 1)
+	reactor.eventChan = make(chan Event, 10)
 	return reactor
 }

--- a/upnp/event.go
+++ b/upnp/event.go
@@ -281,8 +281,8 @@ func (this *upnpDefaultReactor) ServeHTTP(writer http.ResponseWriter, request *h
 func MakeReactor() Reactor {
 	reactor := &upnpDefaultReactor{}
 	reactor.eventMap = make(upnpEventMap)
-	reactor.subscrChan = make(chan *upnpEventRecord)
-	reactor.unpackChan = make(chan *upnpEvent)
-	reactor.eventChan = make(chan Event)
+	reactor.subscrChan = make(chan *upnpEventRecord, 1)
+	reactor.unpackChan = make(chan *upnpEvent, 1)
+	reactor.eventChan = make(chan Event, 1)
 	return reactor
 }


### PR DESCRIPTION
Looks like the order of things happening is causing code to execute in an order which causes a blocking write to a channel.

This change enables things to coalesce without locking up.

Fixes #4 